### PR TITLE
Generate fastas in container.

### DIFF
--- a/batch_container/README.md
+++ b/batch_container/README.md
@@ -1,0 +1,17 @@
+When setting up virtual environment, first make sure you have deactivated any other venvs. Then, navigate to the `batch_container` directory and run:
+
+```
+python3 -m venv venv
+. venv/bin/activate
+pip install -r dev_requirements.txt
+```
+
+Then, edit the file `venv/bin/activate`. Add this line at the end of the file:
+
+```
+export PYTHONPATH="/absolute/path/to/collage/model/repo:$PYTHONPATH"
+```
+
+Replace `/absolute/path/to/collage/model/repo` with your own local collage repo destination. Note it must be an absolute path! ...Also install the correct requirements file from the local collage repo. TODO(auberon): Update when pyproject.toml is configured for model repo. The current approach manlges the PYTHONPATH even once the venv is deactivated.
+
+Note that this will use a DIFFERENT venv than the one to be created in the `sam` directory of this same repo. This is by design. Make sure you are using the correct venv for testing the correct portion.

--- a/batch_container/app/job_runner.py
+++ b/batch_container/app/job_runner.py
@@ -1,27 +1,24 @@
+import argparse
 import io
 import sys
 
 import boto3
 
-from collage.fasta import parse_fasta
-from collage.generator import beam_generator
+from collage.fasta import parse_fasta, to_fasta
+from collage.generator import beam_generator, seq_scores_to_seq_dict
 from collage.model import initialize_collage_model
 
-# TODO(auberon): Make these configurable
-MODEL_FILE_PATH = "/models/Ecoli.pt"
-USE_GPU = True
-BEAM_SIZE = 100
 
-def download_predict_upload(bucket, object_name, input_prefix, output_prefix, model_file_path, beam_size, use_gpu):
+def download_predict_upload(bucket, object_name, input_prefix, output_prefix, model_path, beam_size, use_cpu):
     print(f"{bucket=} {object_name=} {input_prefix=} {output_prefix=}")
     s3_client = boto3.client('s3')
-    input_key = input_prefix+object_name
+    input_key = input_prefix + object_name
     print(f"{input_key=}")
     resp = s3_client.get_object(
-                                Bucket=bucket,
-                                Key=input_key,
-                            )
-    
+        Bucket=bucket,
+        Key=input_key,
+    )
+
     input_stream = resp["Body"]
     with io.TextIOWrapper(input_stream, encoding="utf-8") as input_fasta:
         seq_dict = parse_fasta(input_fasta, True)
@@ -30,25 +27,60 @@ def download_predict_upload(bucket, object_name, input_prefix, output_prefix, mo
     # Currently only makes predictions for first protein in FASTA
     # TODO(auberon): Allow multi-protein predictions?
     first_protein = list(seq_dict.values())[0]
-    model = initialize_collage_model(model_file_path, use_gpu)
-    predictions = beam_generator(model, first_protein, max_seqs=beam_size)
+    model = initialize_collage_model(model_path, not use_cpu)
+    negLLs = beam_generator(model, first_protein, max_seqs=beam_size)
 
-    output_object = str(predictions)
-    output_key = output_prefix+object_name
+    seq_dict = seq_scores_to_seq_dict(negLLs)
+    output_fasta = to_fasta(seq_dict)
+    output_key = output_prefix + object_name
     print(f"{output_key=}")
     s3_client.put_object(
-        Body=output_object,
+        Body=output_fasta,
         Bucket=bucket,
         Key=output_key,
     )
     print("Predictions uploaded")
 
+
+def parse_args(args: list):
+    '''
+    Read in arguments
+    '''
+
+    parser = argparse.ArgumentParser(usage='job_runner.py [optional arguments] bucket_name object_name input_prefix output_prefix',
+                                     description='Downloads an input FASTA from s3, runs a collage prediction on it, and uploads the result.',
+                                     formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument('bucket',
+                        type=str,
+                        help='Name of the s3 bucket to download/upload from/to')
+    parser.add_argument('object_name',
+                        type=str,
+                        help='Name of the input object in s3 WITHOUT any prefix')
+    parser.add_argument('input_prefix',
+                        type=str,
+                        help='Prefix of the input object in s3')
+    parser.add_argument('output_prefix',
+                        type=str,
+                        help='Prefix of where to store the output object in s3')
+    parser.add_argument('--model_path',
+                        type=str,
+                        default="/models/Ecoli.pt",
+                        help='Path to the pretrained model file on the local machine')
+    parser.add_argument('--beam_size',
+                        type=int,
+                        default=100,
+                        help='Number of beams to use in beam search')
+    parser.add_argument('--use_cpu',
+                        action='store_true',
+                        help='Use CPU for CoLLAGE training instead of GPU')
+
+    return parser.parse_args(args)
+
+
 def main(args):
     print(f"The arguments I got were: {args}")
-    # TODO(auberon): Make more robust with argparse?
-    if len(args) != 4:
-        raise TypeError("Expected 4 arguments. Got: ", args)
-    download_predict_upload(*args, MODEL_FILE_PATH, BEAM_SIZE, USE_GPU)
+    download_predict_upload(**vars(parse_args(args)))
+
 
 if __name__ == "__main__":
     main(sys.argv[1:])

--- a/batch_container/dev_requirements.txt
+++ b/batch_container/dev_requirements.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest==7.4.2

--- a/batch_container/requirements.txt
+++ b/batch_container/requirements.txt
@@ -1,1 +1,2 @@
 boto3==1.28.68
+# TODO: Add collage once it's published

--- a/batch_container/tests/conftest.py
+++ b/batch_container/tests/conftest.py
@@ -1,35 +1,7 @@
 import io
-import sys
 from unittest.mock import Mock, patch, MagicMock
 
-# Attempt to import the module, and if it fails, create a mock.
-# TODO(auberon): Look into less jank way to mock collage
-# Challenge is that real collage may not be available at test time
-# This challenge will be resolved once there is a pip installable version of collage
-# Then it can just be mocked like any normal module
-try:
-    import collage
-except ImportError:
-    sys.modules['collage'] = MagicMock()
-
-try:
-    import collage.fasta
-except ImportError:
-    parse_fasta_result = {"mock-sequence": "mock_sequence-data"}
-    fasta_module_mock = MagicMock()
-    fasta_module_mock.parse_fasta.return_value = {"mock-sequence": "mock_sequence-data"}
-    sys.modules['collage.fasta'] = fasta_module_mock
-
-try:
-    import collage.generator
-except ImportError:
-    sys.modules['collage.generator'] = MagicMock()
-
-try:
-    import collage.model
-except ImportError:
-    sys.modules['collage.model'] = MagicMock()
-
+# TODO(auberon): Improve this mocking to not be as complicated
 def mock_boto3_client(config):
     '''
     Patches in a mock boto3 client and stores it in config._boto_patch

--- a/batch_container/tests/test_job_runner.py
+++ b/batch_container/tests/test_job_runner.py
@@ -2,21 +2,24 @@ import boto3
 from app.job_runner import download_predict_upload
 from unittest import mock
 
+
 @mock.patch('app.job_runner.beam_generator')
 @mock.patch('app.job_runner.initialize_collage_model')
 @mock.patch('app.job_runner.parse_fasta')
 def test_job_runner_gets_file_and_uploads_predictions_file_to_s3(mocked_parse, mocked_init, mocked_beam):
+    # TODO(auberon): Don't mock parsing, and instead have s3 mock return actual fasta?
     mocked_parse.return_value = {"mock-sequence": "mock_sequence-data"}
-    
+    mocked_beam.return_value = {"TAGCAT": -42, "GAGAGA": -43}
+
     bucket = "mock-bucket"
     object_name = "mock-object-name"
     input_prefix = "mock-input-prefix/"
     output_prefix = "mock-output-prefix/"
     model_path = "/mock/path/to/model"
     beam_size = 100
-    use_gpu = False
+    use_cpu = True
 
-    download_predict_upload(bucket, object_name, input_prefix, output_prefix, model_path, beam_size, use_gpu)
+    download_predict_upload(bucket, object_name, input_prefix, output_prefix, model_path, beam_size, use_cpu)
 
     s3_client = boto3.client('s3')
     s3_get_call = s3_client.get_object.call_args.kwargs
@@ -26,6 +29,4 @@ def test_job_runner_gets_file_and_uploads_predictions_file_to_s3(mocked_parse, m
     s3_put_call = s3_client.put_object.call_args.kwargs
     assert s3_put_call["Bucket"] == "mock-bucket"
     assert s3_put_call["Key"] == "mock-output-prefix/mock-object-name"
-    # Skipping body validation for now as it will be different once the data is actually processed
-
-
+    assert s3_put_call["Body"] == ">seq0: negLL: -42\nTAGCAT\n>seq1: negLL: -43\nGAGAGA\n"

--- a/batch_container/tests/test_job_runner.py
+++ b/batch_container/tests/test_job_runner.py
@@ -1,7 +1,13 @@
 import boto3
 from app.job_runner import download_predict_upload
+from unittest import mock
 
-def test_job_runner_gets_file_and_uploads_predictions_file_to_s3():
+@mock.patch('app.job_runner.beam_generator')
+@mock.patch('app.job_runner.initialize_collage_model')
+@mock.patch('app.job_runner.parse_fasta')
+def test_job_runner_gets_file_and_uploads_predictions_file_to_s3(mocked_parse, mocked_init, mocked_beam):
+    mocked_parse.return_value = {"mock-sequence": "mock_sequence-data"}
+    
     bucket = "mock-bucket"
     object_name = "mock-object-name"
     input_prefix = "mock-input-prefix/"


### PR DESCRIPTION
Running the container now produces a fasta instead of a likelihood dictionary

Improved batch_container dependency management.
- Improves batch_container so it can use a local copy of collage during
  development. This greatly simplifies the testing setup as well.

- Added dev dependencies for batch_container.

- This will all be further improved once the collage model repository is
  packaged.

Add robust argument parsing and fix fasta generation.
- Uses argparse to make job_runner fully configurable when running.

- Fixes issue where fasta was inverted.

- Updates tests to check body of uploaded file in job_runner.
